### PR TITLE
Fix case WiFiUdp include

### DIFF
--- a/Melvana.ino
+++ b/Melvana.ino
@@ -18,7 +18,7 @@
 
 
 #include <ESP8266WiFi.h>
-#include <WifiUDP.h>
+#include <WiFiUdp.h>
 
 #ifdef MDNSSERVICE
 	#include <ESP8266mDNS.h>


### PR DESCRIPTION
This makes it compile on case sensitive filesystems too. 
